### PR TITLE
fix: resolve -Werror compiler warnings in TL322X/TL521X drivers

### DIFF
--- a/tl_ble_sdk/drivers/TL322X/can.c
+++ b/tl_ble_sdk/drivers/TL322X/can.c
@@ -1186,7 +1186,7 @@ unsigned char can_read_rx_mb(can_chn_e chn,unsigned char mb_index,can_frame_t* f
  */
 _attribute_ram_code_sec_ //BLE SDK USE
 unsigned char canfd_read_rx_mb(can_chn_e chn,unsigned char mb_index,can_fd_frame_t* frame){
-    unsigned char status;
+    unsigned char status = 0xff;
     unsigned int cs_temp;
     unsigned int can_id;
     unsigned char rx_code;

--- a/tl_ble_sdk/drivers/TL322X/keyscan_ana.c
+++ b/tl_ble_sdk/drivers/TL322X/keyscan_ana.c
@@ -139,7 +139,7 @@ static void ks_ana_sar_adc_init(ks_ana_mode_e ks_ana_mode)
  */
 static void ks_ana_mode_config(ks_ana_mode_e ks_ana_mode, unsigned char hall_init_time)
 {
-    ks_ana_config_t ks_ana_cfg;
+    ks_ana_config_t ks_ana_cfg = {0};
     switch (ks_ana_mode)
     {
     case KEYSCAN_1XADC_8K_ONCE_MODE:

--- a/tl_ble_sdk/drivers/TL322X/lin.c
+++ b/tl_ble_sdk/drivers/TL322X/lin.c
@@ -154,6 +154,9 @@ static void lin_reset(lin_num_e lin_num)
  */
 static void lin_uart_init(lin_num_e lin_num)
 {
+    if (lin_num >= LIN_NUM) {
+        return;
+    }
     reg_lin_uart_ctrl0(lin_num)   = ((reg_lin_uart_ctrl0(lin_num) & (~FLD_LIN_UART_BPWC_O)) | s_lin_hw_ctb[lin_num].bwpc); // set bwpc
     reg_lin_uart_clk_div(lin_num) = (s_lin_hw_ctb[lin_num].div | FLD_LIN_UART_CLK_DIV_EN);                                 // set div_clock
 

--- a/tl_ble_sdk/drivers/TL323X/spi.h
+++ b/tl_ble_sdk/drivers/TL323X/spi.h
@@ -1453,27 +1453,6 @@ void spi_master_write_read_full_duplex(spi_sel_e spi_sel, unsigned char *write_d
  */
 void spi_master_read(spi_sel_e spi_sel, unsigned char *data, unsigned int len);
 
-/**
- * @brief       This function serves to set master rx dma burst size
- * @param[in]   spi_sel      - the spi module.
- * @param[in]   burst_size   - dma burst size.
- * @return      none.
- * @note        - gpsi tx dma only support burst1.
- *              - If the set burst size is larger than burst1 (burst2/burst4), the length of the dma transfer must be a multiple of the corresponding burst size,e.g., burst size= burst2,  dma transfer length must be a multiple of 8 bytes.
- *              - Must be configured after spi_set_tx_dma_config().
- */
-void spi_set_dma_tx_burst(spi_sel_e spi_sel, dma_burst_size_e burst_size);
-
-/**
- * @brief       This function serves to set master rx dma burst size
- * @param[in]   spi_sel     - the spi module.
- * @param[in]   burst_size   - dma burst size
- * @return      none.
- * @note        - gpsi rx dma only support burst1.
- *              - If the set burst size is larger than burst1 (burst2), the length of the dma transfer must be a multiple of the corresponding burst size,e.g., burst size= burst2,  dma transfer length must be a multiple of 8 bytes.
- *              - Must be configured after spi_set_master_rx_dma_config().
- */
-void spi_set_dma_rx_burst(spi_sel_e spi_sel, dma_burst_size_e burst_size);
 
 /**
   * @brief     This function serves to config slave rx_dma channel llp.

--- a/tl_ble_sdk/drivers/TL521X/can.c
+++ b/tl_ble_sdk/drivers/TL521X/can.c
@@ -1169,7 +1169,7 @@ unsigned char can_read_rx_mb(can_chn_e chn,unsigned char mb_index,can_frame_t* f
  *            0           - Rx Message Buffer is already overflowed and has been read successfully.
  */
 unsigned char canfd_read_rx_mb(can_chn_e chn,unsigned char mb_index,can_fd_frame_t* frame){
-    unsigned char status = 0;   /* ble add avoid warings */
+    unsigned char status = 0xff;
     unsigned int cs_temp;
     unsigned int can_id;
     unsigned char rx_code;

--- a/tl_ble_sdk/drivers/TL521X/i2c.c
+++ b/tl_ble_sdk/drivers/TL521X/i2c.c
@@ -25,7 +25,7 @@
 
 static unsigned char i2c_dma_tx_chn[1];
 static unsigned char i2c_dma_rx_chn[1];
-
+#define I2C_CHN_NUM   1
 dma_config_t i2c_tx_dma_config[1] = {
   {
     .dst_req_sel    = DMA_REQ_I2C0_TX,     //tx req
@@ -41,7 +41,7 @@ dma_config_t i2c_tx_dma_config[1] = {
     .priority       = 0,
     .write_num_en   = 0,
     .auto_en        = 0, //must 0
-  },
+  }
 
 };
 dma_config_t i2c_rx_dma_config[1] = {
@@ -59,7 +59,7 @@ dma_config_t i2c_rx_dma_config[1] = {
     .priority       = 0,
     .write_num_en   = 1,
     .auto_en        = 0, //must 0
-  },
+  }
 };
 
 i2c_timeout_error_t g_i2c_timeout_error[1] = {
@@ -67,7 +67,7 @@ i2c_timeout_error_t g_i2c_timeout_error[1] = {
      .g_i2c_error_timeout_us   = 0xffffffff,
      .i2c_timeout_handler      = i2c0_timeout_handler,
      .g_i2c_error_timeout_code = I2C_API_ERROR_TIMEOUT_NONE,
-     },
+     }
 };
 
 /**
@@ -423,6 +423,9 @@ void i2c_master_write_dma(i2c_chn_e chn,unsigned char id, unsigned char *data, u
 {
     i2c_clr_irq_status(chn,I2C_TX_BUF_STATUS);
     reg_i2c_id(chn)= (id & (~FLD_I2C_WRITE_READ_BIT)); //BIT(0):R:High  W:Low
+    if (chn >= I2C_CHN_NUM){
+       return;
+    }
 
     dma_set_size(i2c_dma_tx_chn[chn], len, DMA_WORD_WIDTH);
     dma_set_address(i2c_dma_tx_chn[chn], (unsigned int)(data), reg_i2c_data_buf0_addr(chn));
@@ -448,6 +451,9 @@ void i2c_master_read_dma(i2c_chn_e chn,unsigned char id, unsigned char *rx_data,
     i2c_clr_irq_status(chn,I2C_RX_BUF_STATUS);
     reg_i2c_id(chn) = id | FLD_I2C_WRITE_READ_BIT; //BIT(0):R:High  W:Low
     reg_i2c_ctrl3(chn) |= FLD_I2C_RNCK_EN;         //i2c rnck enable.
+    if (chn >= I2C_CHN_NUM){
+        return;
+    }
 
     dma_set_wnum_dis(i2c_dma_rx_chn[chn]);         //The data received by the master is the same length as the data sent, so there is no need for a writer_num.
     dma_set_size(i2c_dma_rx_chn[chn], len, DMA_WORD_WIDTH);
@@ -469,6 +475,10 @@ void i2c_master_read_dma(i2c_chn_e chn,unsigned char id, unsigned char *rx_data,
 void i2c_slave_set_tx_dma(i2c_chn_e chn,unsigned char *data, unsigned int len)
 {
     i2c_clr_irq_status(chn,I2C_TX_BUF_STATUS);
+    if (chn >= I2C_CHN_NUM){
+        return;
+    }
+
     dma_set_address(i2c_dma_tx_chn[chn], (unsigned int)(data), reg_i2c_data_buf0_addr(chn));
     dma_set_size(i2c_dma_tx_chn[chn], len, DMA_WORD_WIDTH);
     dma_chn_en(i2c_dma_tx_chn[chn]);
@@ -489,6 +499,10 @@ void i2c_slave_set_tx_dma(i2c_chn_e chn,unsigned char *data, unsigned int len)
 */
 void i2c_slave_set_rx_dma(i2c_chn_e chn,unsigned char *data, unsigned int len)
 {
+    if (chn >= I2C_CHN_NUM){
+        return;
+    }
+
     dma_chn_dis(i2c_dma_rx_chn[chn]);
     i2c_clr_irq_status(chn,I2C_RX_BUF_STATUS);
     dma_set_address(i2c_dma_rx_chn[chn], reg_i2c_data_buf0_addr(chn), (unsigned int)(data));

--- a/tl_ble_sdk/drivers/TL521X/spi.c
+++ b/tl_ble_sdk/drivers/TL521X/spi.c
@@ -144,12 +144,12 @@ dma_config_t gspi1_slave_rx_dma_config = {
  */
 __attribute__((weak)) void gspi_timeout_handler(unsigned int spi_error_timeout_code)
 {
-    g_spi_timeout_error[GSPI_MODULE].g_spi_error_timeout_code = spi_error_timeout_code;
+    g_spi_timeout_error[0].g_spi_error_timeout_code = spi_error_timeout_code;
 }
 
 __attribute__((weak)) void gspi1_timeout_handler(unsigned int spi_error_timeout_code)
 {
-    g_spi_timeout_error[GSPI1_MODULE].g_spi_error_timeout_code = spi_error_timeout_code;
+    g_spi_timeout_error[1].g_spi_error_timeout_code = spi_error_timeout_code;
 }
 
 /**
@@ -170,7 +170,7 @@ __attribute__((weak)) void gspi1_timeout_handler(unsigned int spi_error_timeout_
   */
 void spi_set_error_timeout(spi_sel_e spi_sel, unsigned int timeout_us)
 {
-    g_spi_timeout_error[spi_sel].g_spi_error_timeout_us = timeout_us;
+    g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us = timeout_us;
 }
 
 /**
@@ -179,7 +179,7 @@ void spi_set_error_timeout(spi_sel_e spi_sel, unsigned int timeout_us)
    */
 spi_api_error_timeout_code_e spi_get_error_timeout_code(spi_sel_e spi_sel)
 {
-    return g_spi_timeout_error[spi_sel].g_spi_error_timeout_code;
+    return g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_code;
 }
 
 /**
@@ -473,11 +473,11 @@ void spi_slave_init(spi_sel_e spi_sel, spi_mode_type_e mode)
     if (spi_sel == GSPI1_MODULE) {
         reg_rst6 |= FLD_RST6_GPSI1;
         reg_clk_en6 |= FLD_CLK6_GSPI1_EN;
-        reg_gspi1_clk_set = ((FLD_GSPI_CLK_MOD & (unsigned char)(sys_clk.pll_clk / 48)) | (2 << 8));
+        reg_gspi1_clk_set = ((FLD_GSPI1_CLK_MOD & (unsigned char)(sys_clk.pll_clk / 48)) | (2 << 8));
     } else {
         reg_rst1 |= FLD_RST1_GSPI;
         reg_clk_en1 |= FLD_CLK1_GSPI_EN;
-        reg_gspi_clk_set = ((FLD_GSPI1_CLK_MOD & (unsigned char)(sys_clk.pll_clk / 48)) | (2 << 8));
+        reg_gspi_clk_set = ((FLD_GSPI_CLK_MOD & (unsigned char)(sys_clk.pll_clk / 48)) | (2 << 8));
     }
     reg_spi_ctrl3(spi_sel) &= (~FLD_SPI_MASTER_MODE);                                         //slave.
     reg_spi_ctrl3(spi_sel) |= FLD_SPI_AUTO_HREADY_EN;                                         //slave.
@@ -598,7 +598,7 @@ drv_api_status_e spi_master_send_cmd(spi_sel_e spi_sel, unsigned char cmd)
     spi_tx_fifo_clr(spi_sel);
     spi_set_transmode(spi_sel, SPI_MODE_NONE_DATA); //nodata.
     spi_set_cmd(spi_sel, cmd);
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -623,14 +623,14 @@ drv_api_status_e spi_write(spi_sel_e spi_sel, unsigned char *data, unsigned int 
 
     //The tx _fifo depth of the gspi is 8 bytes. When the remaining size in the tx_fifo is not less than 4 bytes, the MCU will move the data according to the word length.
     for (unsigned int i = 0; i < word_len; i++) {
-        if (SPI_WAIT(spi_txfifo_num_is_word, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_NUM_WORD)) {
+        if (SPI_WAIT(spi_txfifo_num_is_word, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_NUM_WORD)) {
             return DRV_API_TIMEOUT;
         }
         reg_spi_wr_rd_data_word(spi_sel) = ((unsigned int *)data)[i];
     }
     //When the remaining size in tx_fifo is less than 4 bytes, the MCU moves the data according to the word length.
     for (unsigned int i = 0; i < single_len; i++) {
-        if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
+        if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
             return DRV_API_TIMEOUT;
         }
         reg_spi_wr_rd_data(spi_sel, i % 4) = data[(word_len * 4) + i];
@@ -656,14 +656,14 @@ drv_api_status_e spi_read(spi_sel_e spi_sel, unsigned char *data, unsigned int l
     unsigned char single_len = len & 3;
     //When the data size in rx_fifo is not less than 4 bytes, the MCU moves the data according to the word length.
     for (unsigned int i = 0; i < word_len; i++) {
-        if (SPI_WAIT(spi_rxfifo_num_is_word, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_RXFIFO_NUM_WORD)) {
+        if (SPI_WAIT(spi_rxfifo_num_is_word, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_RXFIFO_NUM_WORD)) {
             return DRV_API_TIMEOUT;
         }
         ((unsigned int *)data)[i] = reg_spi_wr_rd_data_word(spi_sel);
     }
     //When the data size in rx_fifo is less than 4 bytes, the MCU moves the data according to the word length.
     for (unsigned char i = 0; i < single_len; i++) {
-        if (SPI_WAIT(spi_rxfifo_is_empty, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_RXFIFO_EMPTY)) {
+        if (SPI_WAIT(spi_rxfifo_is_empty, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_RXFIFO_EMPTY)) {
             return DRV_API_TIMEOUT;
         }
         data[(word_len * 4) + i] = reg_spi_wr_rd_data((spi_sel), i % 4);
@@ -687,7 +687,7 @@ drv_api_status_e spi_master_write(spi_sel_e spi_sel, unsigned char *data, unsign
     spi_set_transmode(spi_sel, SPI_MODE_WRITE_ONLY);
     spi_set_cmd(spi_sel, 0x00); //when  cmd  disable that  will not sent cmd,just trigger spi send.
     spi_write(spi_sel, (unsigned char *)data, len);
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -717,7 +717,7 @@ drv_api_status_e spi_master_write_read(spi_sel_e spi_sel, unsigned char *wr_data
     spi_set_cmd(spi_sel, 0x00); //when  cmd  disable that  will not sent cmd,just trigger spi send.
     spi_write(spi_sel, (unsigned char *)wr_data, wr_len);
     spi_read(spi_sel, (unsigned char *)rd_data, rd_len);
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -750,7 +750,7 @@ drv_api_status_e spi_master_write_plus(spi_sel_e spi_sel, unsigned char cmd, uns
     if (data_len != 0) {
         spi_write(spi_sel, (unsigned char *)data, data_len);
     }
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -775,13 +775,13 @@ drv_api_status_e spi_master_write_repeat(spi_sel_e spi_sel, unsigned char *data,
     spi_set_cmd(spi_sel, 0x00); //when  cmd  disable that  will not sent cmd,just trigger spi send.
     for (i = 0; i < repeat_time; i++) {
         for (j = 0; j < len; j++, k++) {
-            if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
+            if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
                 return DRV_API_TIMEOUT;
             }
             reg_spi_wr_rd_data(spi_sel, k % 4) = data[j];
         }
     }
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -812,13 +812,13 @@ drv_api_status_e spi_master_write_repeat_plus(spi_sel_e spi_sel, unsigned char c
     spi_set_cmd(spi_sel, cmd);
     for (i = 0; i < repeat_time; i++) {
         for (j = 0; j < data_len; j++, k++) {
-            if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
+            if (SPI_WAIT(spi_txfifo_is_full, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_TXFIFO_FULL)) {
                 return DRV_API_TIMEOUT;
             }
             reg_spi_wr_rd_data(spi_sel, k % 4) = data[j];
         }
     }
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -844,7 +844,7 @@ drv_api_status_e spi_master_read_plus(spi_sel_e spi_sel, unsigned char cmd, unsi
     spi_rx_cnt(spi_sel, data_len);
     spi_set_cmd(spi_sel, cmd);
     spi_read(spi_sel, (unsigned char *)data, data_len);
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;
@@ -875,7 +875,7 @@ drv_api_status_e spi_master_write_read_plus(spi_sel_e spi_sel, unsigned char cmd
     spi_set_cmd(spi_sel, cmd);
     spi_write(spi_sel, (unsigned char *)addrs, addr_len);
     spi_read(spi_sel, (unsigned char *)data, data_len);
-    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
+    if (SPI_WAIT(spi_is_busy, spi_sel, g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_us, g_spi_timeout_error[spi_sel - 1].spi_timeout_handler, SPI_API_ERROR_TIMEOUT_BUS_BUSY)) {
         return DRV_API_TIMEOUT;
     }
     return DRV_API_SUCCESS;

--- a/tl_ble_sdk/drivers/TL521X/spi.h
+++ b/tl_ble_sdk/drivers/TL521X/spi.h
@@ -447,7 +447,7 @@ static inline void spi_hw_fsm_reset(spi_sel_e spi_sel)
         reg_rst1 &= (~FLD_RST1_GSPI);
         reg_rst1 |= FLD_RST1_GSPI;
     }
-    g_spi_timeout_error[spi_sel].g_spi_error_timeout_code = SPI_API_ERROR_TIMEOUT_NONE;
+    g_spi_timeout_error[spi_sel - 1].g_spi_error_timeout_code = SPI_API_ERROR_TIMEOUT_NONE;
 }
 
 /**
@@ -1473,28 +1473,6 @@ void spi_master_write_read_full_duplex(spi_sel_e spi_sel, unsigned char *write_d
  * @return      none.
  */
 void spi_master_read(spi_sel_e spi_sel, unsigned char *data, unsigned int len);
-
-/**
- * @brief       This function serves to set master rx dma burst size
- * @param[in]   spi_sel      - the spi module.
- * @param[in]   burst_size   - dma burst size.
- * @return      none.
- * @note        - gpsi tx dma only support burst1.
- *              - If the set burst size is larger than burst1 (burst2/burst4), the length of the dma transfer must be a multiple of the corresponding burst size,e.g., burst size= burst2,  dma transfer length must be a multiple of 8 bytes.
- *              - Must be configured after spi_set_tx_dma_config().
- */
-void spi_set_dma_tx_burst(spi_sel_e spi_sel, dma_burst_size_e burst_size);
-
-/**
- * @brief       This function serves to set master rx dma burst size
- * @param[in]   spi_sel     - the spi module.
- * @param[in]   burst_size   - dma burst size
- * @return      none.
- * @note        - gpsi rx dma only support burst1.
- *              - If the set burst size is larger than burst1 (burst2), the length of the dma transfer must be a multiple of the corresponding burst size,e.g., burst size= burst2,  dma transfer length must be a multiple of 8 bytes.
- *              - Must be configured after spi_set_master_rx_dma_config().
- */
-void spi_set_dma_rx_burst(spi_sel_e spi_sel, dma_burst_size_e burst_size);
 
 /**
   * @brief     This function serves to config slave rx_dma channel llp.


### PR DESCRIPTION
Fix compilation errors when building with CONFIG_COMPILER_WARNINGS_AS_ERRORS=y:

- TL322X/TL521X can.c: initialize  variable in canfd_read_rx_mb() to avoid -Wmaybe-uninitialized when rx_code doesn't match any branch
- TL322X keyscan_ana.c: zero-initialize  struct in ks_ana_mode_config() to avoid -Wmaybe-uninitialized in default switch branch
- TL322X lin.c: add bounds check in lin_uart_init() to prevent -Warray-bounds on s_lin_hw_ctb[] access when lin_num equals LIN_NUM